### PR TITLE
ci(pr): run terraform plan on PR verify

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -12,7 +12,7 @@ jobs:
           tf_actions_version: 0.12.14
           tf_actions_subcommand: 'init'
           tf_actions_working_dir: terraform
-          args: '-var-file=./var/default.tfvars'
+          args: '-var-file="./var/default.tfvars"'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -24,7 +24,7 @@ jobs:
           tf_actions_version: 0.12.14
           tf_actions_subcommand: 'plan'
           tf_actions_working_dir: terraform
-          args: '-var-file=./var/default.tfvars'
+          args: '-var-file="./var/default.tfvars"'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Troubleshooting Terraform `-var-file` config by running plan on verify (probably a good idea anyway)